### PR TITLE
Publish Debian package on pushes to main

### DIFF
--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -1,0 +1,26 @@
+name: Publish Debian package
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish-debian:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+      - name: Install dependencies
+        run: go mod download
+      - name: Run tests
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: go test ./...
+      - name: Publish Debian package
+        env:
+          DEPLOYMENT_SSH_KEY: ${{ secrets.DEPLOYMENT_SSH_KEY }}
+        run: scripts/publish_debian.sh

--- a/scripts/publish_debian.sh
+++ b/scripts/publish_debian.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+VERSION=$(cat "$ROOT_DIR/VERSION")
+
+"$ROOT_DIR/scripts/build_deb.sh"
+
+APT_ROOT="$ROOT_DIR/build/apt"
+rm -rf "$APT_ROOT"
+mkdir -p "$APT_ROOT/pool/main/b/bulksense" "$APT_ROOT/dists/stable/main/binary-amd64"
+cp "$ROOT_DIR/dist/deb/bulksense_${VERSION}_amd64.deb" "$APT_ROOT/pool/main/b/bulksense/"
+
+dpkg-scanpackages "$APT_ROOT/pool" > "$APT_ROOT/dists/stable/main/binary-amd64/Packages"
+gzip -kf "$APT_ROOT/dists/stable/main/binary-amd64/Packages"
+
+cat > "$APT_ROOT/dists/stable/Release" <<RELEASE
+Suite: stable
+Codename: stable
+Components: main
+Architectures: amd64
+Description: bulksense apt repository
+RELEASE
+
+if [[ -z "${DEPLOYMENT_SSH_KEY:-}" ]]; then
+    echo "DEPLOYMENT_SSH_KEY is not set" >&2
+    exit 1
+fi
+
+KEY_FILE=$(mktemp)
+trap 'rm -f "$KEY_FILE"' EXIT
+printf '%s' "$DEPLOYMENT_SSH_KEY" > "$KEY_FILE"
+chmod 600 "$KEY_FILE"
+
+REMOTE="shopify@merah.cassia.ifost.org.au:/var/www/vhosts/packages.industrial-linguistics.com/htdocs/shopify"
+
+rsync -avz -e "ssh -i $KEY_FILE -o StrictHostKeyChecking=no" "$APT_ROOT/" "$REMOTE/apt/"

--- a/scripts/publish_release.sh
+++ b/scripts/publish_release.sh
@@ -4,25 +4,9 @@ set -euo pipefail
 ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 VERSION=$(cat "$ROOT_DIR/VERSION")
 
-"$ROOT_DIR/scripts/build_deb.sh"
+"$ROOT_DIR/scripts/publish_debian.sh"
 "$ROOT_DIR/scripts/build_macos.sh" "$VERSION"
 pwsh -File "$ROOT_DIR/scripts/build_windows.ps1" -Version "$VERSION"
-
-APT_ROOT="$ROOT_DIR/build/apt"
-rm -rf "$APT_ROOT"
-mkdir -p "$APT_ROOT/pool/main/b/bulksense" "$APT_ROOT/dists/stable/main/binary-amd64"
-cp "$ROOT_DIR/dist/deb/bulksense_${VERSION}_amd64.deb" "$APT_ROOT/pool/main/b/bulksense/"
-
-dpkg-scanpackages "$APT_ROOT/pool" > "$APT_ROOT/dists/stable/main/binary-amd64/Packages"
-gzip -kf "$APT_ROOT/dists/stable/main/binary-amd64/Packages"
-
-cat > "$APT_ROOT/dists/stable/Release" <<RELEASE
-Suite: stable
-Codename: stable
-Components: main
-Architectures: amd64
-Description: bulksense apt repository
-RELEASE
 
 if [[ -z "${DEPLOYMENT_SSH_KEY:-}" ]]; then
     echo "DEPLOYMENT_SSH_KEY is not set" >&2
@@ -36,6 +20,5 @@ chmod 600 "$KEY_FILE"
 
 REMOTE="shopify@merah.cassia.ifost.org.au:/var/www/vhosts/packages.industrial-linguistics.com/htdocs/shopify"
 
-rsync -avz -e "ssh -i $KEY_FILE -o StrictHostKeyChecking=no" "$APT_ROOT/" "$REMOTE/apt/"
 rsync -avz -e "ssh -i $KEY_FILE -o StrictHostKeyChecking=no" "$ROOT_DIR/dist/macos/" "$REMOTE/macos/"
 rsync -avz -e "ssh -i $KEY_FILE -o StrictHostKeyChecking=no" "$ROOT_DIR/dist/windows/" "$REMOTE/windows/"


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to build, test, and publish the Debian package whenever `main` is updated
- extract Debian publishing into a reusable script and invoke it from the release workflow to avoid duplication

## Testing
- time go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68dda7b6a03c8325b2009cb93730b56a